### PR TITLE
Remove polyfill.io, update MathJax to 4.1.2, fix typesetting timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,7 @@
 </head>
 
 <!-- For MathJax -->
-<script src=" https://polyfill.io/v3/polyfill.min.js?features=es6">
-</script>
-<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+<script id="MathJax-script" defer src="https://cdn.jsdelivr.net/npm/mathjax@4.1.2/tex-mml-chtml.js"></script>
 
 <body>
   <div id="app">

--- a/src/components/CatalaCode.res
+++ b/src/components/CatalaCode.res
@@ -2,8 +2,8 @@
 
 let typesetMathJax: unit => unit = %raw(`
 function typesetMathJax() {
-    if (window.MathJax) {
-      window.MathJax.typeset();
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      window.MathJax.typesetPromise();
     }
   }
 `)
@@ -11,14 +11,29 @@ function typesetMathJax() {
 module DangerouslySetInnerHtml = {
   @react.component
   let make = (~htmlFile) => {
+    let (htmlState, setHtmlState) = React.useState(_ => None)
     React.useEffect(() => {
-      // This assumes MathJax to be loaded in the page. Necessary for the
-      // LaTeX components of the Catala code to be typeset after any
-      // change in the collapsible structure of the page.
-      typesetMathJax()
+      Assets.Html.getExn(htmlFile)
+      ->Promise.thenResolve(html => setHtmlState(_ => Some(html)))
+      ->Promise.done
       None
     })
-    <RawHtml htmlFile={htmlFile} className="catala-code w-full" />
+    // typesetMathJax runs after the DOM is updated with the HTML content
+    React.useEffect1(
+      () => {
+        switch htmlState {
+        | Some(_) => typesetMathJax()
+        | None => ()
+        }
+        None
+      },
+      [htmlState],
+    )
+    switch htmlState {
+    | Some(html) =>
+      <div className="catala-code w-full" dangerouslySetInnerHTML={"__html": html} />
+    | None => <div className="catala-code w-full"> {"Loading..."->React.string} </div>
+    }
   }
 }
 module Span = {


### PR DESCRIPTION
Fixes #93.

## Summary

- Remove the `polyfill.io` CDN script tag from `index.html` (compromised supply-chain CDN, [June 2024 incident](https://sansec.io/research/polyfill-supply-chain-attack)); the polyfill was unused — MathJax 4 and all target browsers support ES6 natively
- Update MathJax from an unpinned `@3` CDN reference to a pinned `4.1.2` from jsDelivr; confirmed MathJax 4 has no dependency on polyfill.io
- Fix a latent bug in `CatalaCode.DangerouslySetInnerHtml`: `typesetMathJax` was called on the component's own mount, before the child `RawHtml` component had finished its async HTML fetch — so MathJax never saw the math content. The component now owns the HTML fetch state itself and calls `typesetPromise()` in a `useEffect1([htmlState])`, which React guarantees runs after the DOM is updated. Also switches from the deprecated synchronous `typeset()` to `typesetPromise()`, required in MathJax 4 due to async font loading.